### PR TITLE
Introduce some fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React lightweight library for anchor scrolling and navigation tied to URL hash.
 
 ## Features
 
-This library exports multiple helpers designed to make your anchor navigation works seamlessly.
+This library exports multiple helpers designed to make your anchor navigation works seamlessly. Check the [examples](./examples/custom-section.html)
 
 Four components :
 
@@ -119,12 +119,7 @@ interface TProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 
 TODO
 
-### Embedded Demos
-
-<iframe src="./examples/basic.html" style="width:100%; height:300px"></iframe>
-
 ## Roadmap
 
 - Finish completing the README
-- Add an example project
 - Add testing

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # react-anchor-navigation
 
+![GitHub package.json dependency version (prod)](https://img.shields.io/github/package-json/dependency-version/koala-interactive/react-anchor-navigation/react)
+![npm type definitions](https://img.shields.io/npm/types/react-anchor-navigation)
+
 React lightweight library for anchor scrolling and navigation tied to URL hash.
 
 ## Features
@@ -13,11 +16,6 @@ Four components :
 - [AnchorProvider](#AnchorProvider)
 - [AnchorSection](#AnchorSection)
 
-Two hooks used internally (only import it for advanced or customized handling) :
-
-- [useAnchorScrollListener](#useAnchorScrollListener)
-- [useHash](#useHash)
-
 ## Getting Started
 
 ### Installation
@@ -26,21 +24,19 @@ This project uses react hooks and is therefore reliant on react version >=16.8.6
 
 To install and use react-anchor-navigation, add it to your package.json and modules with the following command line :
 
-```js
+```ts
 npm install --save react-anchor-navigation
 ```
 
 OR
 
-```js
+```ts
 yarn add react-anchor-navigation
 ```
 
 ### Usage
 
-All our features are in these four components, for advanced and customized usage, please refers to the internal custom hooks documentation [here](#Advanded-Usage)
-
-```jsx
+```tsx
 import {
   AnchorContext,
   AnchorLink,
@@ -53,7 +49,7 @@ import {
 
 AnchorProvider is our top level contextProvider. Wrap it around your topmost component for your view :
 
-```JSX
+```tsx
 <AnchorProvider>
   <YourView />
 </AnchorProvider>
@@ -65,7 +61,7 @@ It will provide the AnchorContext to all children.
 
 AnchorContext is the context you can yield with the new `useContext` hook or with old-fashioned Context.consumer.
 
-```js
+```ts
 const { hash, sections } = useContext(AnchorContext);
 ```
 
@@ -83,13 +79,13 @@ Here is its typing :
 
 AnchorSection is our most used components, it defines the scroll position you will arrive to on navigation/reloading
 
-```js
+```ts
 <AnchorSection className="dBlock anchor" id="definitions" />
 ```
 
 Its props are the usual HTMLElement's props (`className, data-*`), along with an id used for recognizing the update the current hash on scroll.
 
-```js
+```ts
 interface TProps extends React.HTMLAttributes<HTMLElement> {
   id: string;
 }
@@ -97,7 +93,7 @@ interface TProps extends React.HTMLAttributes<HTMLElement> {
 
 Internally it creates a `<b/>` tag to which we scroll to on reload and detect if we scrolled past it.
 
-```JSX
+```tsx
 <>
   <b {...attributes} />
   {...children}
@@ -108,63 +104,15 @@ Internally it creates a `<b/>` tag to which we scroll to on reload and detect if
 
 AnchorLink is a component made to have an activeClassname if its `href` is the current hash
 
-```js
+```ts
 interface TProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children: React.ReactNode[] | React.ReactNode;
   activeClassName?: string;
 }
 ```
 
-```JSX
+```tsx
 <AnchorLink className="dTable w100 pad15" href="#definitions" activeClassName="blue">
-```
-
-### Advanded Usage
-
-Here will be informations about our internal processing hooks. In most cases and without needs for great customizations, you will not need to import those hooks.
-
-#### useHash
-
-useHash is a custom react hook used internally in AnchorProvider. We still export it if you want to have an advanced usage (Otherwise it should not be needed) and not use AnchorProvider.
-
-Usage :
-
-```
-export interface TStore {
-  sections: TContext["sections"];
-  blockScrollEvent: boolean;
-  scroller: HTMLElement | null;
-}
-
-const ref = useRef<TStore>
-  {
-    sections: [],
-    blockScrollEvent: false,
-    scroller: null
-  };
-
-const [hash, setHash] = useHash(ref);
-```
-
-| Key              |         Type         |                                                                                   Description |
-| ---------------- | :------------------: | --------------------------------------------------------------------------------------------: |
-| sections         |   `HTMLElement[]`    |   List of the registered sections elements that we watch, in our codebase it is AnchorSection |
-| blockScrollEvent |      `boolean`       | Internal boolean to avoid handling native scroll event on hash change causing a second scroll |
-| scroller         | `HTMLElement | null` |                                                                        Scroller element's ref |
-
-The hash and its setter are then sent to the AnchorContext.
-
-For further informations you can look into the sources for AnchorProvider.
-
-#### useAnchorScrollListener
-
-useAnchorScrollListener is another custom react hook used internally in AnchorProvider. If you wish not to use AnchorProvider this hook can help you customize your anchor handling.
-
-It is called with the setter from `useHash`. The `ref` is the `TStore` also sent to `useHash`. These two hooks works best together.
-Internally it listens to the onScroll event and update the hash if one registered section has been detected above our scroll position.
-
-```js
-useAnchorScrollListener(ref, setHash);
 ```
 
 ### Custom Components Examples
@@ -173,7 +121,7 @@ TODO
 
 ### Embedded Demos
 
-TODO
+<iframe src="./examples/basic.html" style="width:100%; height:300px"></iframe>
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ AnchorProvider is our top level contextProvider. Wrap it around your topmost com
 </AnchorProvider>
 ```
 
+| Key         | Type                |                                                                                                      Description |
+| ----------- | :-----------------: | ---------------------------------------------------------------------------------------------------------------: |
+| offset      | `number`            | The offset amount of pixels from the top, usefull when handling fixed header or sticky navigation (default: `0`) |
+| getScroller | `() => HTMLElement` | Function to returns the scrollable element  (default: `body`)                                                    |
+
 It will provide the AnchorContext to all children.
 
 #### AnchorContext
@@ -74,6 +79,7 @@ Here is its typing :
 | registerSection   |        `(element: HTMLElement) => void`         | Function to add a Section to our sections list, our scrollEvent listener will then update the hash if the section is scrolled to |
 | unregisterSection |        `(element: HTMLElement) => void`         |                 Function to remove a Section to our sections list, our scrollEvent listener will then stop checking this section |
 | setHash           | `(hash: string, withScroll?: boolean) => void;` |                              Setter function from the internal useHash hooks, use it to programmatically change the current hash |
+| offset            |                    `number`                     |                 The offset amount of pixels from the top, usefull when handling fixed header or sticky navigation (default: `0`) |
 
 #### AnchorSection
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Basic page</title>
+    <title>Basic usage</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Basic page</title>
+    <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>
+    <script src="../dist/umd/react-anchor-navigation.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <style>
+    body, html, ul, li {
+      margin:0;
+      padding: 0;
+      font-family: Arial;
+    }
+    .selected {
+      background-color: #f0f0f0;
+      color: purple;
+    }
+    nav {
+      position: fixed;
+      box-shadow: 0 1px 5px rgba(0,0,0,0.5);
+      text-align: center;
+      width: 100%;
+      background-color: white;
+    }
+    li {
+      display: inline-block;
+      width: 25%;
+    }
+    a {
+      display: inline-block;
+      width: 100%;
+      padding: 20px 0;
+      color: black;
+      text-decoration: none;
+      color: #555ccc
+    }
+    main { padding-top:58px; }
+    section {
+      height: 150vh;
+      background: linear-gradient(#e66465, #9198e5);
+      padding: 50px;
+      font-size: 70px;
+      color: white;
+      text-align: center;
+    }
+  </style>
+  <body>
+    <div id="react-root"></div>
+    <script type="text/babel">
+const {AnchorProvider, AnchorLink, AnchorSection} = ReactAnchorNavigation;
+const list = Array.from({ length: 4 }, (v, i) => ({
+  id : `part-${i + 1}`,
+  title: `Part ${i + 1}`
+}));
+
+const Root = () => (
+  <AnchorProvider top={58}>
+    <nav>
+      { list.map((item) => (
+        <li key={item.id}>
+          <AnchorLink href={`#${item.id}`} activeClassName="selected">{item.title}</AnchorLink>
+        </li>
+      )) }
+    </nav>
+    <main>
+      { list.map((item) => (
+        <AnchorSection id={item.id} key={item.id}>
+          <section>
+            <h2>{item.title}</h2>
+            ⬇️
+          </section>
+        </AnchorSection>
+      ))}
+    </main>
+  </AnchorProvider>
+);
+
+ReactDOM.render(<Root />, document.getElementById('react-root'));
+    </script>
+  </body>
+</html>

--- a/examples/custom-link.html
+++ b/examples/custom-link.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Basic page</title>
+    <title>Custom link component</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>

--- a/examples/custom-link.html
+++ b/examples/custom-link.html
@@ -35,11 +35,12 @@
       color: #555ccc;
       transition: all 0.3s;
       border-bottom: 5px solid transparent;
-      border-bottom: 5px solid #4bb6f5
+      line-height: 25px;
     }
     a.selected {
       background-color: #d4e3ef;
       color: #000980;
+      border-bottom: 5px solid #4bb6f5
     }
     main {
       padding-top:58px;
@@ -57,7 +58,21 @@
     <div id="react-root"></div>
     <script type="text/babel">
 
-const {AnchorProvider, AnchorLink, AnchorSection} = ReactAnchorNavigation;
+const {AnchorProvider, AnchorContext, AnchorSection} = ReactAnchorNavigation;
+const {useContext} = React;
+
+const CustomLink = ({children, className, ...attributes}) => {
+  const {hash} = useContext(AnchorContext);
+  const selected = hash === attributes.href;
+  const newClassName = (className ? `${className}` : '') + (selected ? ' selected' : '');
+
+  return (
+    <a {...attributes} className={newClassName}>
+      {selected ? '🎨' : ' '} {children}
+    </a>
+  );
+}
+
 const list = Array.from({ length: 4 }, (v, i) => ({
   id : `part-${i + 1}`,
   title: `Part ${i + 1}`
@@ -68,7 +83,7 @@ const Root = () => (
     <nav>
       { list.map((item) => (
         <li key={item.id}>
-          <AnchorLink href={`#${item.id}`} activeClassName="selected">{item.title}</AnchorLink>
+          <CustomLink href={`#${item.id}`} activeClassName="selected">{item.title}</CustomLink>
         </li>
       )) }
     </nav>

--- a/examples/custom-section.html
+++ b/examples/custom-section.html
@@ -33,13 +33,14 @@
       color: black;
       text-decoration: none;
       color: #555ccc;
+      transition: color 0.3s, background-color 0.3s;
       transition: all 0.3s;
       border-bottom: 5px solid transparent;
-      border-bottom: 5px solid #4bb6f5
     }
     a.selected {
       background-color: #d4e3ef;
       color: #000980;
+      border-bottom: 5px solid #4bb6f5;
     }
     main {
       padding-top:58px;
@@ -47,21 +48,73 @@
     section {
       height: 150vh;
       background: linear-gradient(230deg,#a24bcf,#4b79cf,#4bc5cf);
-      padding: 50px;
+      padding: 100px;
       font-size: 52px;
       color: white;
       text-align: center;
+      transition: all 0.3s;
+      border-color: black;
+      background-size: 200%
+    }
+    section.selected {
+      border-left: 10vw solid black;
+      border-right: 10vw solid black;
+      animation: BgAnimation 3s ease infinite;
+      color: black;
+      font-size: 100px;
+      text-shadow: 0 0 10px rgba(255,255,255,0.5);
+    }
+    @keyframes BgAnimation {
+        0%{background-position:50% 50%}
+        50%{background-position:100% 100%}
+        100%{background-position:50% 50%}
     }
   </style>
   <body>
     <div id="react-root"></div>
     <script type="text/babel">
 
-const {AnchorProvider, AnchorLink, AnchorSection} = ReactAnchorNavigation;
+const {AnchorProvider, AnchorLink, AnchorContext} = ReactAnchorNavigation;
+const {useContext, useRef, useEffect} = React;
+
 const list = Array.from({ length: 4 }, (v, i) => ({
   id : `part-${i + 1}`,
   title: `Part ${i + 1}`
 }));
+
+const CustomSection = ({ children, ...attributes }) => {
+  const { registerSection, unregisterSection, hash } = useContext(AnchorContext);
+  const ref = useRef(null);
+  const selected = attributes.id === hash.substr(1);
+  const newClassName = (attributes.className ? `${attributes.className}` : '') + (selected ? ' selected' : '');
+
+  // Logic to register/unregister component
+  // when added/removed from DOM
+  useEffect(() => {
+    if (ref.current) {
+      registerSection(ref.current);
+
+      // Initialization of the component.
+      // If mounted from a SPA without server-side rendering the hash will not
+      // scroll at all, so do it manually
+      if (attributes.id === location.hash.substr(1)) {
+        ref.current.scrollIntoView();
+      }
+    }
+
+    return () => {
+      if (ref.current) {
+        unregisterSection(ref.current);
+      }
+    };
+  }, []);
+
+  return (
+    <section {...attributes} className={newClassName} ref={ref}>
+      {children}
+    </section>
+  );
+}
 
 const Root = () => (
   <AnchorProvider offset={58}>
@@ -74,12 +127,10 @@ const Root = () => (
     </nav>
     <main>
       { list.map((item) => (
-        <AnchorSection id={item.id} key={item.id}>
-          <section>
-            <h2>{item.title}</h2>
-            ⬇️
-          </section>
-        </AnchorSection>
+        <CustomSection id={item.id} key={item.id}>
+          <h2>{item.title}</h2>
+          <p>⬇️</p>
+        </CustomSection>
       ))}
     </main>
   </AnchorProvider>

--- a/examples/custom-section.html
+++ b/examples/custom-section.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Basic page</title>
+    <title>Custom section component</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,4 @@ export * from "./src/components/AnchorLink";
 export * from "./src/components/AnchorProvider";
 export * from "./src/components/AnchorSection";
 
-export * from "./src/hooks/useAnchorScrollListener";
-export * from "./src/hooks/useHash";
 export as namespace reactAnchorNavigation;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "del dist && rollup -c"
   },
+  "files": [
+    "dist/",
+    "index.d.ts"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/koala-interactive/react-anchor-navigation.git"
@@ -42,7 +46,6 @@
     "del-cli": "^3.0.0",
     "rollup": "^1.30.0",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-size-snapshot": "^0.10.0",
     "rollup-plugin-terser": "^5.2.0",
     "tslib": "^1.10.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ import path from "path";
 import babel from "rollup-plugin-babel";
 import { terser } from "rollup-plugin-terser";
 import resolve from "@rollup/plugin-node-resolve";
-import builtins from "rollup-plugin-node-builtins";
 import { sizeSnapshot } from "rollup-plugin-size-snapshot";
 const { version, license, name } = require("./package.json");
 const licenseData = fs.readFileSync(path.join(process.cwd(), "LICENSE.md"), {
@@ -20,13 +19,15 @@ const bannerPlugin = {
 const exportFormat = format => ({
   input: "src/index.ts",
   output: {
-    name,
+    name: name.replace(/(^|-)(\w)/g, ($0, $1, $2) => $2.toUpperCase()),
     format,
-    file: `dist/${format}/react-anchor-navigation.js`
+    file: `dist/${format}/react-anchor-navigation.js`,
+    globals: {
+      react: "React"
+    }
   },
   external: ["react"],
   plugins: [
-    builtins(),
     resolve({
       extensions: [".tsx", ".ts"]
     }),
@@ -43,6 +44,6 @@ const exportFormat = format => ({
       output: { comments: /@license/ }
     }),
     sizeSnapshot()
-  ].filter(v => v)
+  ]
 });
 export default ["umd", "cjs", "esm"].map(exportFormat);

--- a/src/components/AnchorContext.tsx
+++ b/src/components/AnchorContext.tsx
@@ -3,6 +3,7 @@ import { createContext } from "react";
 import { noop } from "../utils/noop";
 
 export interface TContext {
+  offset: number;
   sections: HTMLElement[];
   hash: string;
   registerSection: (element: HTMLElement) => void;
@@ -11,6 +12,7 @@ export interface TContext {
 }
 
 export const AnchorContext = createContext<TContext>({
+  offset: 0,
   sections: [],
   hash: "",
   registerSection: noop,

--- a/src/components/AnchorProvider.tsx
+++ b/src/components/AnchorProvider.tsx
@@ -6,6 +6,7 @@ import { getElementScrollPosition } from "../utils/getElementScrollPosition";
 import { AnchorContext, TContext } from "./AnchorContext";
 
 export interface TStore {
+  offset: number;
   sections: TContext["sections"];
   blockScrollEvent: boolean;
   scroller: HTMLElement | null;
@@ -14,10 +15,12 @@ export interface TStore {
 interface TProps {
   children: React.ReactNode[];
   getScroller?: () => TStore["scroller"];
+  offset?: number;
 }
 
-export function AnchorProvider({ children, getScroller }: TProps) {
+export function AnchorProvider({ children, getScroller, offset }: TProps) {
   const ref = useRef<TStore>({
+    offset: offset || 0,
     sections: [],
     blockScrollEvent: false,
     scroller: null
@@ -66,6 +69,7 @@ export function AnchorProvider({ children, getScroller }: TProps) {
   return (
     <AnchorContext.Provider
       value={{
+        offset,
         hash,
         sections: ref.current.sections,
         setHash,

--- a/src/components/AnchorProvider.tsx
+++ b/src/components/AnchorProvider.tsx
@@ -18,9 +18,9 @@ interface TProps {
   offset?: number;
 }
 
-export function AnchorProvider({ children, getScroller, offset }: TProps) {
+export function AnchorProvider({ children, getScroller, offset = 0 }: TProps) {
   const ref = useRef<TStore>({
-    offset: offset || 0,
+    offset,
     sections: [],
     blockScrollEvent: false,
     scroller: null

--- a/src/hooks/useAnchorScrollListener.ts
+++ b/src/hooks/useAnchorScrollListener.ts
@@ -17,15 +17,15 @@ export function useAnchorScrollListener(
 ) {
   useEffect(() => {
     const throttleScrollEvent = throttle(() => {
-      const { blockScrollEvent, sections, scroller } = ref.current;
+      const { blockScrollEvent, sections, scroller, offset } = ref.current;
 
       if (blockScrollEvent || !sections.length) {
         return;
       }
 
-      const y = scroller
+      const y = (scroller
         ? scroller.scrollTop
-        : window.pageYOffset || document.documentElement.scrollTop;
+        : window.pageYOffset || document.documentElement.scrollTop) + offset;
 
       // Before the first element
       if (getElementScrollPosition(sections[0], scroller) > y) {
@@ -37,7 +37,10 @@ export function useAnchorScrollListener(
       const selectedIndex = sections.findIndex(
         item => getElementScrollPosition(item, scroller) > y
       );
-      const selectedElement = sections[Math.max(selectedIndex - 1, 0)];
+
+      const selectedElement = selectedIndex === -1
+        ? sections[sections.length - 1]
+        : sections[Math.max(selectedIndex - 1, 0)];
 
       if (selectedElement) {
         setHash(`#${selectedElement.id}`, false);

--- a/src/hooks/useAnchorScrollListener.ts
+++ b/src/hooks/useAnchorScrollListener.ts
@@ -16,7 +16,7 @@ export function useAnchorScrollListener(
   setHash: TContext["setHash"]
 ) {
   useEffect(() => {
-    const throttleScrollEvent = throttle(() => {
+    const onScroll = () => {
       const { blockScrollEvent, sections, scroller, offset } = ref.current;
 
       if (blockScrollEvent || !sections.length) {
@@ -29,7 +29,7 @@ export function useAnchorScrollListener(
 
       // Before the first element
       if (getElementScrollPosition(sections[0], scroller) > y) {
-        setHash(`#`, false);
+        setHash("#", false);
         return;
       }
 
@@ -45,9 +45,11 @@ export function useAnchorScrollListener(
       if (selectedElement) {
         setHash(`#${selectedElement.id}`, false);
       }
-    }, 100);
+    };
 
+    const throttleScrollEvent = throttle(onScroll, 100);
     addEventListener("scroll", throttleScrollEvent, PASSIVE_OPTION);
+    onScroll();
 
     return () => {
       removeEventListener("scroll", throttleScrollEvent, PASSIVE_OPTION);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,9 @@ import { AnchorLink } from "./components/AnchorLink";
 import { AnchorProvider } from "./components/AnchorProvider";
 import { AnchorSection } from "./components/AnchorSection";
 
-import { useHash } from "./hooks/useHash";
-import { useAnchorScrollListener } from "./hooks/useAnchorScrollListener";
-
 export {
   AnchorContext,
   AnchorLink,
   AnchorProvider,
-  AnchorSection,
-  useAnchorScrollListener,
-  useHash
+  AnchorSection
 };

--- a/src/utils/supportPassiveEvent.ts
+++ b/src/utils/supportPassiveEvent.ts
@@ -1,7 +1,7 @@
 // Passive event support
 // https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 export const SUPPORT_PASSIVE_EVENT =
-  process.env.BUILD_TARGET === "client" &&
+  typeof addEventListener !== 'undefined' &&
   (() => {
     let supportsPassiveOption = false;
 


### PR DESCRIPTION
- Removed access to useAnchorScrollListener and useHash (no interest as it can only be used internally).
- Add a basic example page and embedded it on readme.
- Remove the dependency of an unused plugin `rollup-plugin-node-builtins`.
- Fixes umd build not working at all.
- Add support for "offset" props.
- Fixes last section item was not triggering the hash change when scrolling behind.
- Remove the use of `process.env.BUILD_TARGET === "client"` (was only used for our organisation projects)