### PR TITLE
Fixes CI tests and node v13

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,5 +15,8 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Build dist
+        run: yarn build
+
       - name: Run e2e tests
         run: yarn cypress:headless

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "react": ">=16.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
-    "@babel/preset-typescript": "^7.8.3",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
+    "@babel/preset-react": "^7.9.0",
+    "@babel/preset-typescript": "^7.9.0",
     "@rollup/plugin-node-resolve": "^7.0.0",
     "@types/node": "^13.5.0",
     "@types/react": "^16.3.13",


### PR DESCRIPTION
- babel 7.8 got problems with node v13 (impossible to build).
- I removed the dist folder in the previous versoin, so e2e ci were not working (in the past e2e tested the wrong version).